### PR TITLE
perform indirect translation if language model was not found

### DIFF
--- a/src/kotki/kotki.cpp
+++ b/src/kotki/kotki.cpp
@@ -77,7 +77,11 @@ Kotki::Kotki() {
 std::string Kotki::translate(string input, string language) {
   if(!m_models.count(language)) {
     std::cerr << "language << " << language << " not found\n";
-    return "";
+    if(language.length()<4)return "";
+    string firstlang = language.substr(0,2);
+    string secondlang = language.substr(2,2);
+    if(firstlang=="en"||secondlang=="en")return "";
+    return translate(translate(input,firstlang+"en"),"en"+secondlang);
   }
 
   auto result = m_models[language]->translate(input);


### PR DESCRIPTION
Current version of kotki fails if you try to translate for example de->es, if there's no such translation model
With this PR kotki instead of returning an empty string will attempt to translate destlang->en then en->srclang, so dees translation will work if there are deen and enes language models installed