### PR TITLE
Process all batches for large text inputs

### DIFF
--- a/src/kotki/kotki.cpp
+++ b/src/kotki/kotki.cpp
@@ -14,12 +14,18 @@
 string KotkiTranslationModel::translate(string input) {
   if(!initialized) { this->load(); }
 
-  Batch batch;
   marian::Ptr<Request> request = model->makeRequest(std::move(input), m_cache);
 
   model->enqueueRequest(request);
-  model->generateBatch(batch);
-  model->translateBatch(0, batch);
+  // Loop to process all batches from the request
+  while (true) {
+      Batch batch;
+      // If generateBatch returns 0, it means there are no more segments to process.
+      if (model->generateBatch(batch) == 0) {
+          break;
+      }
+      model->translateBatch(0, batch);
+  }
 
   return request->response.target.text;
 }


### PR DESCRIPTION
`KotkiTranslationModel::translate` only processed a single batch of text. When a large input string was provided, it was correctly segmented into multiple batches by the `TextProcessor` and enqueued. However, the `translate` function would only generate and translate the first batch, leaving the remaining segments unprocessed in the `BatchingPool`.

This resulted in an incomplete translation, where
`request->response.target.text` would remain empty because the `ResponseBuilder` was never triggered for the full set of segments.

This commit resolves the issue by introducing a loop in the `translate` function.

Fixes #8